### PR TITLE
Fix scroll on Firefox

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -85,6 +85,7 @@ form .form-group label input[type="checkbox"] {
 
 .col-options {
   overflow-y: scroll;
+  height: 100%;
 }
 
 .form-group.field-array .row {


### PR DESCRIPTION
Hello,
while on Chrome the whole UI works as expected, on Firefox 64.0.2 the column `.col-options` does not respond to any scroll action.

This PR fix that, and has no effect on Chrome.